### PR TITLE
Relative and absolute paths in output file

### DIFF
--- a/src/Processors/OutputFilePath.php
+++ b/src/Processors/OutputFilePath.php
@@ -16,13 +16,15 @@ final class OutputFilePath
     {
         $path = new SplFileInfo(trim($filePath));
         $extension = $path->getExtension();
+        $directory = realpath($path->getPath());
+        Assert::true($directory !== false, "Directory '{$path->getPath()}' does not exist");
         Assert::eq(
             $extension,
             $expectedExtension,
             "Output file is expected to have extension '.{$expectedExtension}', '.{$extension}' given"
         );
 
-        return new OutputFilePath($path);
+        return new OutputFilePath(new SplFileInfo($directory . '/' . $path->getBasename()));
     }
 
     private function __construct(private SplFileInfo $filePath)

--- a/tests/unit/Processors/OutputFilePathTest.php
+++ b/tests/unit/Processors/OutputFilePathTest.php
@@ -29,4 +29,22 @@ final class OutputFilePathTest extends TestCase
 
         OutputFilePath::withExpectedExtension('  ', 'txt');
     }
+
+    /** @test */
+    function it_supports_relative_paths()
+    {
+        $currentPath = OutputFilePath::withExpectedExtension('./file.png', 'png');
+        $absolutePath = OutputFilePath::withExpectedExtension(getcwd() . '/file.png', 'png');
+
+        $this->assertEquals(getcwd() . '/file.png', $currentPath->value());
+        $this->assertEquals(getcwd() . '/file.png', $absolutePath->value());
+    }
+
+    /** @test */
+    function it_prevents_attempting_to_same_in_invalid_directories()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectErrorMessage("Directory './src/gjs2s3e2js' does not exist");
+        OutputFilePath::withExpectedExtension('./src/gjs2s3e2js/file.png', 'png');
+    }
 }


### PR DESCRIPTION
- [x] Allow passing relative and absolute paths as output files in commands
- [x] Prevent output file paths within directories that don't exist