### PR TITLE
`object` from DocBlock and FQN as key in Digraph

### DIFF
--- a/src/Graphviz/ObjectHashIdentifier.php
+++ b/src/Graphviz/ObjectHashIdentifier.php
@@ -10,8 +10,7 @@ namespace PhUml\Graphviz;
 use PhUml\Code\WithName;
 
 /**
- * Both `ClassDefinition` and `InterfaceDefinition` objects identifiers are generated using the
- * function `spl_object_hash`
+ * Both `ClassDefinition` and `InterfaceDefinition` objects identifiers are generated using their Fully Qualified Name
  */
 trait ObjectHashIdentifier
 {
@@ -19,6 +18,6 @@ trait ObjectHashIdentifier
 
     public function identifier(): string
     {
-        return (string) $this->name();
+        return $this->name->fullName();
     }
 }

--- a/src/Parser/Code/Builders/TagTypeFactory.php
+++ b/src/Parser/Code/Builders/TagTypeFactory.php
@@ -89,7 +89,18 @@ final class TagTypeFactory
             $type === null => null,
             $type instanceof Nullable => TagType::nullable((string) $type->getActualType()),
             $type instanceof Compound => TagType::compound(array_map('strval', $type->getIterator()->getArrayCopy())),
-            default => TagType::named((string) ($type instanceof Object_ ? $type->getFqsen() : $type))
+            default => $this->fromType($type)
         };
+    }
+
+    private function fromType(Type $type): TagType
+    {
+        if (! $type instanceof Object_) {
+            return TagType::named((string) $type);
+        }
+        if ($type->getFqsen() === null) {
+            return TagType::named((string) $type);
+        }
+        return TagType::named((string) $type->getFqsen());
     }
 }

--- a/tests/src/Fakes/WithDotLanguageAssertions.php
+++ b/tests/src/Fakes/WithDotLanguageAssertions.php
@@ -16,8 +16,9 @@ trait WithDotLanguageAssertions
 {
     public function assertNode(Definition $definition, string $dotLanguage): void
     {
+        $identifier = str_replace('\\', '\\\\', $definition->identifier());
         $this->assertMatchesRegularExpression(
-            "/\"{$definition->identifier()}\" \\[label=<(?:.)+{$definition->name()}(?:.)+> shape=plaintext color=\"#[0-9a-f]{6}\"\\]/",
+            "/\"{$identifier}\" \\[label=<(?:.)+{$definition->name()}(?:.)+> shape=plaintext color=\"#[0-9a-f]{6}\"\\]/",
             $dotLanguage,
             "Definition {$definition->name()} with identifier {$definition->identifier()} cannot be found"
         );
@@ -28,8 +29,10 @@ trait WithDotLanguageAssertions
         Definition $parent,
         string $dotLanguage
     ): void {
+        $parentIdentifier = str_replace('\\', '\\\\', $parent->identifier());
+        $identifier = str_replace('\\', '\\\\', $definition->identifier());
         $this->assertMatchesRegularExpression(
-            "/\"{$parent->identifier()}\" -> \"{$definition->identifier()}\" \\[dir=back arrowtail=empty style=solid color=\"#[0-9a-f]{6}\"\\]/",
+            "/\"{$parentIdentifier}\" -> \"{$identifier}\" \\[dir=back arrowtail=empty style=solid color=\"#[0-9a-f]{6}\"\\]/",
             $dotLanguage,
             "{$definition->name()} identified by {$definition->identifier()} does not inherits {$parent->name()} identified by {$parent->identifier()}"
         );
@@ -40,8 +43,10 @@ trait WithDotLanguageAssertions
         InterfaceDefinition $interface,
         string $dotLanguage
     ): void {
+        $interfaceIdentifier = str_replace('\\', '\\\\', $interface->identifier());
+        $identifier = str_replace('\\', '\\\\', $class->identifier());
         $this->assertMatchesRegularExpression(
-            "/\"{$interface->identifier()}\" -> \"{$class->identifier()}\" \\[dir=back arrowtail=empty style=dashed color=\"#[0-9a-f]{6}\"\\]/",
+            "/\"{$interfaceIdentifier}\" -> \"{$identifier}\" \\[dir=back arrowtail=empty style=dashed color=\"#[0-9a-f]{6}\"\\]/",
             $dotLanguage,
             "{$class->name()} does not implements {$interface->name()}"
         );

--- a/tests/unit/Generators/GenerateDotFileTest.php
+++ b/tests/unit/Generators/GenerateDotFileTest.php
@@ -29,8 +29,8 @@ final class GenerateDotFileTest extends TestCase
 
         $digraph = $this->processor->process($codebase);
 
-        $this->assertNode(A::classNamed('plBase'), $digraph->value());
-        $this->assertNode(A::classNamed('plPhuml'), $digraph->value());
+        $this->assertNode(A::classNamed('phuml\plBase'), $digraph->value());
+        $this->assertNode(A::classNamed('phuml\plPhuml'), $digraph->value());
     }
 
     /** @test */
@@ -42,14 +42,14 @@ final class GenerateDotFileTest extends TestCase
 
         $digraph = $this->processor->process($codebase);
 
-        $base = A::classNamed('plBase');
+        $base = A::classNamed('phuml\plBase');
         $tokenParser = A::classNamed('plStructureTokenparserGenerator');
         $attribute = A::classNamed('plPhpAttribute');
         $class = A::classNamed('plPhpClass');
         $function = A::classNamed('plPhpFunction');
         $parameter = A::classNamed('plPhpFunctionParameter');
         $interface = A::classNamed('plPhpInterface');
-        $uml = A::classNamed('plPhuml');
+        $uml = A::classNamed('phuml\plPhuml');
         $dotProcessor = A::classNamed('plDotProcessor');
         $graphvizProcessor = A::classNamed('plGraphvizProcessor');
         $styleName = A::classNamed('plStyleName');
@@ -60,7 +60,7 @@ final class GenerateDotFileTest extends TestCase
         $statisticsProcessor = A::classNamed('plStatisticsProcessor');
         $structureGenerator = A::classNamed('plStructureGenerator');
         $externalCommand = A::classNamed('plExternalCommandProcessor');
-        $processor = A::classNamed('plProcessor');
+        $processor = A::classNamed('phuml\interfaces\plProcessor');
         $style = A::classNamed('plGraphvizProcessorStyle');
         $this->assertNode($base, $digraph->value());
         $this->assertNode($structureGenerator, $digraph->value());

--- a/tests/unit/Parser/Code/TypeResolverTest.php
+++ b/tests/unit/Parser/Code/TypeResolverTest.php
@@ -18,6 +18,22 @@ use PhUml\Parser\Code\Builders\TagTypeFactory;
 final class TypeResolverTest extends TestCase
 {
     /** @test */
+    function it_resolves_built_in_types()
+    {
+        $useStatements = new UseStatements([]);
+
+        $objectType = $this->resolver->resolveForAttribute('/** @var object */', $useStatements);
+        $mixedType = $this->resolver->resolveForReturn('/** @return mixed */', $useStatements);
+        $stringType = $this->resolver->resolveForParameter('/** @param string[] $test */', '$test', $useStatements);
+        $boolType = $this->resolver->resolveForAttribute('/** @var bool */', $useStatements);
+
+        $this->assertEquals('object', (string) $objectType);
+        $this->assertEquals('mixed', (string) $mixedType);
+        $this->assertEquals('string[]', (string) $stringType);
+        $this->assertEquals('bool', (string) $boolType);
+    }
+
+    /** @test */
     function it_resolves_to_absent_type_if_doc_block_is_invalid()
     {
         $useStatements = new UseStatements([]);


### PR DESCRIPTION
When `object` is given in a DocBlock it resolves to `Object_` type but without a FQSEN value, which makes the `TagTypeFactory` fail when `null` FQSEN is converted to ''

- [x] Add check for null and return `object` when FQSEN is `null`

When classes have the same name, they're overwritten in the Digraph creation stage

- [x] Use FQN as key in Digraph
